### PR TITLE
Added match and dump methods to PcapPyBpfProgram

### DIFF
--- a/src/pcappy/__init__.py
+++ b/src/pcappy/__init__.py
@@ -276,6 +276,20 @@ class PcapPyBpfProgram(object):
 
     mask = netmask
 
+    def match(self, packet, length=None, caplen=None):
+        pkt = str(packet)
+        hdr = pcap_pkthdr()
+        if length is None:
+            length = len(pkt)
+        if caplen is None:
+            caplen = length
+        hdr.len = length
+        hdr.caplen = caplen
+        return pcap_offline_filter(pointer(self._bpf), pointer(hdr), pkt)
+
+    def dump(self, options=0):
+        bpf_dump(self._bpf, options)
+
     def __del__(self):
         if self._bpf:
             pcap_freecode(pointer(self._bpf))

--- a/src/pcappy/functions.py
+++ b/src/pcappy/functions.py
@@ -144,6 +144,9 @@ load_func('pcap_compile', c_int, [ pcap_t_ptr, bpf_program_ptr, c_char_p, c_int,
 load_func('pcap_compile_nopcap', c_int, [ c_int, c_int, bpf_program_ptr, c_char_p, c_int, c_uint32 ])
 
 
+load_func('bpf_dump', argtypes=[ bpf_program_ptr, c_int ])
+
+
 load_func('pcap_freecode', argtypes=[ bpf_program_ptr ])
 
 


### PR DESCRIPTION
This allows invoking a filter against a packet using pcap_offline_filter
